### PR TITLE
Add --prune option to git push command in repository mirroring workflow

### DIFF
--- a/.github/workflows/repository_mirroring.yml
+++ b/.github/workflows/repository_mirroring.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Push on mirror
         run: |
             git remote add mirror "${{ vars.MIRROR_URL }}"
-            git push --tags --force mirror "refs/remotes/origin/*:refs/heads/*"
+            git push --tags --force --prune mirror "refs/remotes/origin/*:refs/heads/*"
             echo `git ls-files`
 
       - name: Remove remote


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/repository_mirroring.yml` file. The change modifies the `git push` command to include the `--prune` option, which helps to remove any references in the remote repository that no longer exist in the local repository.

* [`.github/workflows/repository_mirroring.yml`](diffhunk://#diff-baef82c0a88f82eb36d71ffa24ab3c8bc4f622ef656c78bc3f3c80e044a551f2L36-R36): Modified the `git push` command to include the `--prune` option.